### PR TITLE
Add onTransform to user route

### DIFF
--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -22,6 +22,12 @@ class User {
 
 export const user = new Elysia({ prefix: "users" })
   .decorate("user", new User())
+  .onTransform(function log({ body, params, path, request: { method } }) {
+    console.log(`${method} ${path}`, {
+      body,
+      params,
+    });
+  })
   .get("/", ({ user }) => user.data)
   .put("/", ({ user, body: { data } }) => user.add(data), {
     body: t.Object({
@@ -47,9 +53,6 @@ export const user = new Elysia({ prefix: "users" })
       return error(402);
     },
     {
-      params: t.Object({
-        id: t.Number(),
-      }),
       body: t.Object({
         data: t.String(),
       }),


### PR DESCRIPTION
onTransform()
- Is a lifecycle that intercepts the request before/after it is processed
- Is called after routing but before validation
- By default, the lifecycle hook is encapsulated,  is not applied to other plugins (routes that are not defined in the same plugin)- unless we explicitly defined it as scoped or global.